### PR TITLE
fix build issue for gradle 5.x

### DIFF
--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/jni/CocosAndroid.mk
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/jni/CocosAndroid.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := cocos2djs_shared
+LOCAL_MODULE := cocos2djs
 
 LOCAL_MODULE_FILENAME := libcocos2djs
 


### PR DESCRIPTION
Compatible with older versions.
note:
for gradle 5.x, make sure the Gradle Plugin version hight then 3.4.0 .
issue: 
https://forum.cocos.org/t/topic/102285/2
